### PR TITLE
Build module to reduce path dependence when calling command

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,12 @@ A visual report containing:
 - Spectrogram image (if generated)
 
 ### CSV Report (`.csv`)
-Contains the same metrics in a tabular format for spreadsheets, analysis, or integration with other tools.  
+Contains the same metrics in a tabular format for spreadsheets, analysis, or integration with other tools.
 *(No spectrogram images in CSV.)*
 
 ## Troubleshooting
 
-**FFmpeg Not Found**  
+**FFmpeg Not Found**
 If you see:
 ```
 ERROR: ffprobe executable not found
@@ -166,7 +166,7 @@ ERROR: ffprobe executable not found
 - Or ensure its location is in your system's PATH.
 - Or use the `--ffprobe-path` argument.
 
-**Errors in Logs**  
+**Errors in Logs**
 Run with the `-l` flag to generate a detailed log file inside the report directory for debugging.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -34,9 +34,17 @@ git clone https://github.com/oren-cohen/whatsmybitrate.git
 cd whatsmybitrate
 ```
 
-### Install Python dependencies
+### (Recommended) set up a virtual environment for the package
+
 ```bash
-pip install -r requirements.txt
+python -m venv .wmbr-venv
+source .wmbr-venv/bin/activate
+```
+
+### Install this package with its dependencies
+
+```bash
+pip install -e .
 ```
 
 ### Install FFmpeg
@@ -73,7 +81,7 @@ The script is invoked from the command line with options and input targets. Inpu
 
 ### View available arguments
 ```bash
-python whatsmybitrate.py -h
+python -m whatsmybitrate -h
 ```
 
 **Output:**
@@ -103,23 +111,23 @@ Performance & Utility Arguments:
 
 **Analyze all supported audio files in the current directory:**
 ```bash
-python whatsmybitrate.py . -a
+python -m whatsmybitrate . -a
 ```
 
 **Analyze all `.flac` files in a specific directory and subfolders, using multiprocessing:**
 ```bash
-python whatsmybitrate.py /path/to/music -t flac -r -m
+python -m whatsmybitrate /path/to/music -t flac -r -m
 ```
 
 **Generate a CSV report for specific MP3 files:**
 ```bash
-python whatsmybitrate.py "song 1.mp3" "another song.mp3" -c
+python -m whatsmybitrate "song 1.mp3" "another song.mp3" -c
 ```
 *Note: On Windows `cmd`, glob patterns like `*.mp3` are not automatically expanded. Use `-a` or `-t` instead.*
 
 **Analyze a directory recursively and disable spectrograms and logging:**
 ```bash
-python whatsmybitrate.py /path/to/archive -a -r -n
+python -m whatsmybitrate /path/to/archive -a -r -n
 ```
 
 ## Supported Audio Formats

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["hatchling >= 1.26"]
+build-backend = "hatchling.build"
+
+[project]
+name = "whatsmybitrate"
+version = "0.0.1"
+dependencies = [
+"librosa>=0.11.0",
+"matplotlib>=3.7.1",
+"numpy<2",
+"tqdm>=4.66.0",
+"soundfile>=0.12.1",
+"audioread>=2.1.9",
+"scipy>=1.10.0,<1.14.0",
+]
+requires-python = ">=3.8,<3.13"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-librosa>=0.11.0
-matplotlib>=3.7.1
-numpy<2
-tqdm>=4.66.0
-soundfile>=0.12.1
-audioread>=2.1.9
-scipy>=1.10.0,<1.14.0

--- a/whatsmybitrate.py
+++ b/whatsmybitrate.py
@@ -265,7 +265,7 @@ def main():
         except RuntimeError:
             pass
 
-    parser = argparse.ArgumentParser(prog="whatsmybitrate.py", description="Analyzes audio files to estimate their true quality.", formatter_class=argparse.RawTextHelpFormatter)
+    parser = argparse.ArgumentParser(prog="whatsmybitrate", description="Analyzes audio files to estimate their true quality.", formatter_class=argparse.RawTextHelpFormatter)
     io_group = parser.add_argument_group('Input & Output Arguments')
     io_group.add_argument("input", nargs="*", help="One or more audio files, a directory, or a shell glob pattern (e.g., 'C:\\Music\\*.flac').")
     io_group.add_argument("-c", "--csv", action='store_true', help="Output the report in CSV format.")

--- a/whatsmybitrate.py
+++ b/whatsmybitrate.py
@@ -3,7 +3,7 @@
 import os
 import glob
 import matplotlib
-import multiprocessing 
+import multiprocessing
 matplotlib.use('Agg')
 from datetime import datetime
 import argparse
@@ -13,7 +13,7 @@ import sys
 import warnings
 from abc import ABC, abstractmethod
 import fnmatch
-from multiprocessing import Pool 
+from multiprocessing import Pool
 import shutil
 from functools import partial
 
@@ -156,7 +156,7 @@ class AnalysisRunner:
     def _setup_logger(self):
         log_level = logging.DEBUG if self.config.log else logging.INFO
         logger.setLevel(log_level)
-        
+
         if logger.hasHandlers():
             logger.handlers.clear()
 
@@ -218,7 +218,7 @@ class AnalysisRunner:
         logger.info(f"Found {len(self.files_to_process)} file(s) to analyze.")
 
         gen_spec = not self.config.no_spectrogram and not self.config.csv
-        
+
         if self.config.multiprocessing and len(self.files_to_process) > 1:
             return self._run_in_parallel(gen_spec)
         else:
@@ -276,7 +276,7 @@ def main():
     type_group.add_argument("-t", "--type", help="Scan for a single file TYPE (e.g., 'mp3', 'flac').")
     type_group.add_argument("-a", "--all", action="store_true", help="Scan for all supported audio types. Overrides specific patterns.")
     scan_group.add_argument("-r", "--recursive", action="store_true", help="Scan directories recursively.")
-    
+
     util_group = parser.add_argument_group('Utility Arguments')
     util_group.add_argument("--ffprobe-path", help="Specify the full path to the ffprobe executable.")
     util_group.add_argument("-n", "--no-spectrogram", action="store_true", help="Disable spectrogram generation for HTML reports.")
@@ -305,10 +305,10 @@ def main():
 
     output_format = 'csv' if args.csv else 'html'
     report_path = os.path.join(output_dir, f"{base_name}.{output_format}")
-    
+
     log_path = os.path.join(output_dir, f"{base_name}.log") if args.log else None
     assets_path = os.path.join(output_dir, 'assets') if not args.no_spectrogram and not args.csv else None
-    
+
     if assets_path:
         os.makedirs(assets_path, exist_ok=True)
 
@@ -323,13 +323,13 @@ def main():
         reporter = CsvReportGenerator(results_data)
     else:
         reporter = HtmlReportGenerator(results_data)
-    
+
     reporter.generate(report_path)
     logger.info(f"Report saved to: {report_path}")
-    
+
     console_reporter = ConsoleReportGenerator(results_data)
     console_reporter.generate()
-    
+
     runner.write_logs(results_data)
 
     logger.info(f"\nAnalysis complete. All outputs saved in directory: {output_dir}")


### PR DESCRIPTION
I would have liked to set this up so that `whatsmybitrate` gets  inserted into `<VENV-path>/bin/` so that it can be called without `python -m`, but my packaging chops are not that good!

---

Create the module "whatsmybitrate" so that the program can be called via

`python -m whatsmybitrate ...` without any explicit reference to the full path.

Build is accomplished by the more standard

`pip install -e .`

In the parent commit, to run this script from directories other than the build
directory, one would have to call

`python <path-to>/whatsmybitrate ...`, which is a bit cumbersome.

---
* Updated documentation in README
* Updated `--help` output

This uses the `hatchling` backend.